### PR TITLE
Remove development check from the railtie's #to_prepare - it's redundant

### DIFF
--- a/lib/display_case/railtie.rb
+++ b/lib/display_case/railtie.rb
@@ -1,7 +1,9 @@
 module DisplayCase
   class Railtie < Rails::Railtie
+    # http://guides.rubyonrails.org/configuring.html#initialization-events
+    # "to_prepare will run upon every request in development, but only once (during boot-up) in production and test."
     config.to_prepare do
-      DisplayCase.find_definitions if Rails.env.development?
+      DisplayCase.find_definitions
     end    
   end
 end


### PR DESCRIPTION
Running display_case 0.0.3 in production meant that my app could not find any exhibits located in 'app/exhibits/'

Removing the development check in the railtie's #to_prepare fixes this issue.

From http://guides.rubyonrails.org/configuring.html#initialization-events

> to_prepare: Run after the initializers are ran for all Railties (including the application itself), but before eager loading and the middleware stack is built. More importantly, will run upon every request in development, but only once (during boot-up) in production and test.

In development this would have the same behaviour as prior to this patch, but production would see DisplayCase.find_definitions executed once.
