### PR TITLE
returning proper enumerator

### DIFF
--- a/lib/display_case/enumerable_exhibit.rb
+++ b/lib/display_case/enumerable_exhibit.rb
@@ -34,9 +34,10 @@ module DisplayCase
     end
 
     def each(*)
-      super do |e|
-        yield exhibit(e)
-      end
+      __getobj__.map do |e|
+        yield exhibit(e) if block_given?
+        exhibit(e)
+      end.each
     end
 
     # `render '...', :collection => self` will call #to_ary on this

--- a/spec/exhibits/enumerable_exhibit_spec.rb
+++ b/spec/exhibits/enumerable_exhibit_spec.rb
@@ -38,6 +38,19 @@ describe DisplayCase::EnumerableExhibit do
       subject.each do |e| results << e end
       results.must_equal(["exhibit(e1)", "exhibit(e2)", "exhibit(e3)"])
     end
+
+    it "returns enumerator" do
+      subject.each.must_be_instance_of(Enumerator)
+    end
+
+    it "chains with_index" do
+      results = []
+      subject.each.with_index do |*e| results << e end
+      results.must_equal([
+                          ["exhibit(e1)", 0],
+                          ["exhibit(e2)", 1],
+                          ["exhibit(e3)", 2]])
+    end
   end
 
   describe "#each_with_index" do


### PR DESCRIPTION
If you try to get enumerator from EnumerableExhibit like this:

``` ruby
books = exhibit find_books
enum = books.each
enum.next
```

It will raise `no block given (yield)` error. You'll get same exception if you try something like this: `books.each.with_index` or `books.each.with_object`.

I've fixed it with this commit. I've added some specs, but I'm unsure if this is the best way to do it.
