### PR TITLE
Add :pop to the list of exhibit_query methods.

### DIFF
--- a/lib/display_case/enumerable_exhibit.rb
+++ b/lib/display_case/enumerable_exhibit.rb
@@ -22,7 +22,7 @@ module DisplayCase
     end
     private_class_method :exhibit_enum
 
-    exhibit_query :[], :fetch, :slice, :values_at, :last
+    exhibit_query :[], :fetch, :slice, :values_at, :last, :pop
     exhibit_enum :select, :grep, :reject, :to_enum, :sort, :sort_by, :reverse
     exhibit_enum :partition do |result|
       result.map{|group| exhibit(group)}

--- a/spec/exhibits/enumerable_exhibit_spec.rb
+++ b/spec/exhibits/enumerable_exhibit_spec.rb
@@ -76,8 +76,8 @@ describe DisplayCase::EnumerableExhibit do
       assert(subject.equal?(subject.to_ary))
     end
   end
-  
-  describe "#to_json" do 
+
+  describe "#to_json" do
     it "returns #as_json from elements in its collection" do
       subject.to_json.must_equal('["exhibit(e1)","exhibit(e2)","exhibit(e3)"]')
       with_custom_as_json = subject.map{|m| m.define_singleton_method(:as_json){|opts={}| 0 }; m }
@@ -125,6 +125,12 @@ describe DisplayCase::EnumerableExhibit do
   describe "#last" do
     it "exhibits the result" do
       subject.last.must_equal("exhibit(e3)")
+    end
+  end
+
+  describe "#pop" do
+    it "exhibits the result" do
+      subject.pop.must_equal("exhibit(e3)")
     end
   end
 


### PR DESCRIPTION
I found that `pop`ing the result of an exhibited list of objects didn't return an exhibited object. So I just added `:pop` to the list of methods to run `exhibit_query` on.

Thanks!
