### PR TITLE
Add ability to pass options hash to render method.

### DIFF
--- a/lib/display_case/enumerable_exhibit.rb
+++ b/lib/display_case/enumerable_exhibit.rb
@@ -51,9 +51,9 @@ module DisplayCase
       as_json.to_json
     end
 
-    def render(template)
+    def render(template, options = {})
       inject(ActiveSupport::SafeBuffer.new) { |output,element|
-        output << element.render(template)
+        output << element.render(template, options)
       }
     end
 

--- a/lib/display_case/exhibit.rb
+++ b/lib/display_case/exhibit.rb
@@ -150,8 +150,8 @@ module DisplayCase
       "#{inspect_exhibits}(#{__getobj__.inspect})"
     end
 
-    def render(template)
-      template.render(:partial => to_partial_path, :object => self)
+    def render(template, options = {})
+      template.render(options.reverse_merge(:partial => to_partial_path, :object => self))
     end
 
     def exhibited?


### PR DESCRIPTION
For example:

```
# in the controller
@images = DisplayCase::Exhibit.exhibit(my_obj.images)

# in the template:
<%= @images.render(self, locals: { my_var: "Hello" }) %>
# then `my_var` is available for use in /images/_image.html.erb
```

I'm not sure how to add a test for this. Unfortunately my `mock`-foo isn't strong. If you can point me in the write direction I'll give it a shot to add a test again... I just couldn't come up with anything that seemed like it would prove this functionality out.
