### PR TITLE
Establish working pattern for rendering partials from an exhibit with a freshly exhibited object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+
 ## Unreleased
 ### Added
 - Change log (this file) (see: http://keepachangelog.com/)
-- `reexhibit` method to allow an exhibited object a chance to re-select the appropriate exhibit for ensuing method call(s). (by @pdobb)
+
+### Fixed
+- [#51](https://github.com/objects-on-rails/display-case/pull/51): Will now re-exhibit an exhibited model when rendering from an exhibit. This ensures that the exhibit chain includes all possible exhibit objects instead of just `self`. (by @pdobb)
 
 
 ## 0.1.0 - 2013-07-22
 ### Added
-- Ability to send an options hash to the `render` method. (by @pdobb)
-- Add `pop` as a query_method on DisplayCase::EnumerableExhibit. This ensures that `pop`ping the result of an exhibited list of objects returns an exhibited object. (by @pdobb)
+- [#47](https://github.com/objects-on-rails/display-case/pull/47): Ability to send an options hash to the `render` method. (by @pdobb)
+- [#45](https://github.com/objects-on-rails/display-case/pull/45): Add `pop` as a query_method on DisplayCase::EnumerableExhibit. This ensures that `pop`ping the result of an exhibited list of objects returns an exhibited object. (by @pdobb)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ class LeagueExhibit < DisplayCase::Exhibit
   end
 
   def render_icon(template)
-    template.render(partial: 'leagues/icon', locals: {league: self})
+    # Use `object` local variable in partial to refer back to the exhibited
+    # object
+    render(template, partial: 'leagues/icon')
+
+    # OR
+
+    # Specify a local variable and "reexhibit" the model associated with `self`.
+    # Using `exhibit(to_model)` ensures that `league`'s exhibit chain includes
+    # all possible exhibit objects instead of just `self` (or LeagueExhibit,
+    # in this example).
+    render(template, partial: 'leagues/icon', locals: { league: exhibit(to_model) })
   end
 end
 ```
@@ -68,6 +78,8 @@ Finally, in your view, you can use your Exhibit:
   <%= league.render_icon(self) %> <!-- self is this "template", the parameter to the method we defined in LeagueExhibit -->
 <% end %>
 ```
+
+Note: See [#51](https://github.com/objects-on-rails/display-case/pull/51) for more on the need for `exhibit(to_model)` when rendering a partial from an exhibit.
 
 Configuration
 -------------

--- a/lib/display_case/exhibit.rb
+++ b/lib/display_case/exhibit.rb
@@ -137,10 +137,6 @@ module DisplayCase
       Exhibit.exhibit(model, context)
     end
 
-    def reexhibit
-      exhibit(to_model)
-    end
-
     def exhibit_chain
       inner_exhibits = __getobj__.respond_to?(:exhibit_chain) ? __getobj__.exhibit_chain : []
       [__class__] + inner_exhibits
@@ -155,7 +151,7 @@ module DisplayCase
     end
 
     def render(template, options = {})
-      template.render(options.reverse_merge(:partial => to_partial_path, :object => self))
+      template.render(options.reverse_merge(:partial => to_partial_path, :object => exhibit(to_model)))
     end
 
     def exhibited?


### PR DESCRIPTION
The need for this isn't easy to explain... and this pull request isn't necessarily what's needed (maybe there's an opportunity to automatically "reexhibit" objects). But this pull request is at least one way to present the issue I've run into along with the quick/easy solution that's been working for me for the past 6 months each time I run into it: the _DisplayCase::Exhibit#reexhibit_ method.

By code example:

``` ruby
  # Given:
  class MyExhibit1 < DisplayCase::Exhibit
    def self.applicable_to?(*); true end

    def foo; "foo" end

    def do_render_from_my_exhibit(context)
      context.render "my_partial", my_local_var: self
    end
  end

  class MyExhibit2 < DisplayCase::Exhibit
    def self.applicable_to?(*); true end

    def bar; "bar" end
  end

  # When executed from console, works as expected:
  ex_obj = DisplayCase::Exhibit(my_obj)
  ex_obj.foo # => "foo"
  ex_obj.bar # => "bar"

  # When executed through a render:
  #1) From within a view template
  @ex_obj.do_render_from_my_exhibit(self)

  #2) From within "my_partial" view template
  my_local_var.foo # => "foo"
  my_local_var.bar # => Undefined method `#bar`!
  # `my_local_var` seems to be "frozen" as a MyExhibit1

  # HOWEVER

  # If we send a "reexhibited" version of self as a local var:
  class MyExhibit1 < DisplayCase::Exhibit
    def do_render_from_my_exhibit(context)
      context.render "my_partial", my_local_var: reexhibit
    end
  end

  # Then:
  # When executed through a render:
  #1) From within a view template
  @ex_obj.do_render_from_my_exhibit(self)

  #2) From within "my_partial" view template
  my_local_var.foo # => "foo"
  my_local_var.bar # => "bar"
  # This works! my_local_var is now able to act like a regular exhibit again.
```

I hope this makes sense. The essence of it is that after performing a [`render`](http://api.rubyonrails.org/classes/ActionView/Helpers/RenderingHelper.html#method-i-render) call, the objects being passed through on the locals hash no longer behave as exhibits should. That is, normally exhibited objects find the first exhibited object that can respond to a method. But after going through a render they only respond to methods on the exhibited object that was passed in, unless reexhibited first.

Also, I was trying to write tests for this example and was having trouble again. Trying to get an exhibited object to go through a `render` call seems like it would require adding a development dependency on Rails and I wasn't sure how to approach it even. And mocking didn't seem able to reproduce the issue.

It desired, I'll try to set up a simplest case working code example... let me know.

I also started a CHANGELONG.md file for the project, so if nothing else maybe you'd like to take that part away from this :).
