### PR TITLE
Use Class.to_s instead of Class.name.to_s

### DIFF
--- a/lib/display_case/find_definitions.rb
+++ b/lib/display_case/find_definitions.rb
@@ -42,6 +42,6 @@ module DisplayCase
     klass_name = error_message.gsub("superclass mismatch for class ", "")
     [klass_name.constantize]
   rescue NameError
-    ObjectSpace.each_object(Class).select{|c| c.name.to_s.split('::').last == klass_name}
+    ObjectSpace.each_object(Class).select{|c| c.to_s.split('::').last == klass_name}
   end
 end


### PR DESCRIPTION
This fixes a bug that can occur if a Class has overridden the
.name method to have an arity > 0. Plus, it reduces 1 step and
should resolve to the same thing in the end.

Here is an example of the bug in action (ignore all of the 0s and 1s):

![image](https://cloud.githubusercontent.com/assets/64674/17482600/8ada5802-5d50-11e6-9994-3003f7c6f802.png)
