### PR TITLE
Fix: Properly reload the deconstantized constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ group :development, :test do
   gem 'activerecord-nulldb-adapter', :git => "git://github.com/nulldb/nulldb.git"
   gem 'rake'
   gem 'json-jruby', :platform => :jruby
-  gem 'bundler', '1.11.2'
 end

--- a/lib/display_case/find_definitions.rb
+++ b/lib/display_case/find_definitions.rb
@@ -24,12 +24,17 @@ module DisplayCase
       rescue TypeError => error
         klass = find_class_candidates(error.message).first # TODO: Is there a way to make this work correctly if there are multiple candidates?
         if klass.ancestors.include?(DisplayCase::Exhibit) && configuration.swallow_superclass_mismatch_for_exhibits?
-          namespace = if klass.name.index('::')
-                        klass.name.split('::')[0..-1].constantize
-                      else
-                        Object
-                      end
-          namespace.send(:remove_const, klass.name.to_sym)
+          delimiter = '::'
+          namespace, klass_name =
+            if klass.name.index(delimiter)
+              klass_names = klass.name.split(delimiter)
+              namespace_name = klass_names[0..-2].join(delimiter).constantize
+              klass_name = klass_names.last
+              [namespace_name, klass_name]
+            else
+              [Object, klass.name]
+            end
+          namespace.send(:remove_const, klass_name.to_sym)
           retry
         else
           raise error


### PR DESCRIPTION
Previously, the code was attempting to constantize an Array. (See #60.)

> The goal is to remove the constant and reload it so it can pick
> up changes, because it was reloading them, but having the old copy
> around was messing things up: any class that had inherited from one
> of these would keep the old copy as what it was inheriting from,
> rather than the new one. So we wanted to remove the constant to
> remove the reference, and add it back in to re-establish it.

The fix is to:
1) Remove all but the *last* constant in a namespaced klass name
2) Join the remainder back into a namespaced string
... and *then* constantize the result, as before.